### PR TITLE
fix(security): use crypto.randomInt for backup and referral codes

### DIFF
--- a/scripts/generate-close-roast.js
+++ b/scripts/generate-close-roast.js
@@ -7,6 +7,7 @@
  * Optional: GROQ_API_KEY (primary), GEMINI_API_KEY (fallback), GEMINI_MODEL, GROQ_MODEL
  */
 
+const { randomInt } = require('crypto');
 const config = require('./roast-prompt.config.js');
 const { generateRoast } = require('./lib/ai-agents');
 
@@ -23,7 +24,7 @@ async function main() {
     ? `PR fue MERGEADO. Rating ${rating}/5. Sonar: ${bugs} bugs, ${hotspots} hotspots.`
     : `PR fue CERRADO/RECHAZADO. Rating ${rating}/5. Sonar: ${bugs} bugs, ${hotspots} hotspots. Veredicto: ${verdict}`;
 
-  const style = config.styles[Math.floor(Math.random() * config.styles.length)];
+  const style = config.styles[randomInt(config.styles.length)];
   const prompt = config.promptTemplate
     .replace(/\{\{action\}\}/g, action)
     .replace(/\{\{context\}\}/g, context)

--- a/scripts/generate-close-roast.js
+++ b/scripts/generate-close-roast.js
@@ -7,7 +7,7 @@
  * Optional: GROQ_API_KEY (primary), GEMINI_API_KEY (fallback), GEMINI_MODEL, GROQ_MODEL
  */
 
-const { randomInt } = require('crypto');
+const { randomInt } = require('node:crypto');
 const config = require('./roast-prompt.config.js');
 const { generateRoast } = require('./lib/ai-agents');
 

--- a/src/auth/services/two-factor.service.spec.ts
+++ b/src/auth/services/two-factor.service.spec.ts
@@ -3,7 +3,7 @@ import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { BadRequestException, UnauthorizedException } from '@nestjs/common';
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { authenticator } from 'otplib';
 import { TwoFactorService } from './two-factor.service';
 import { ObservabilityService } from 'src/shared/observability/observability.service';

--- a/src/auth/services/two-factor.service.ts
+++ b/src/auth/services/two-factor.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable, Logger, UnauthorizedException } from '
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { authenticator } from 'otplib';
-import { createHash, randomInt } from 'crypto';
+import { createHash, randomInt } from 'node:crypto';
 import { Repository } from 'typeorm';
 import { toDataURL } from 'qrcode';
 

--- a/src/auth/services/two-factor.service.ts
+++ b/src/auth/services/two-factor.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable, Logger, UnauthorizedException } from '
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { authenticator } from 'otplib';
-import { createHash } from 'crypto';
+import { createHash, randomInt } from 'crypto';
 import { Repository } from 'typeorm';
 import { toDataURL } from 'qrcode';
 
@@ -226,10 +226,7 @@ export class TwoFactorService {
   private generateBackupCode(): string {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
     const part = (): string =>
-      Array.from(
-        { length: BACKUP_CODE_LENGTH },
-        () => chars[Math.floor(Math.random() * chars.length)],
-      ).join('');
+      Array.from({ length: BACKUP_CODE_LENGTH }, () => chars[randomInt(chars.length)]).join('');
     return `${part()}-${part()}-${part()}`;
   }
 

--- a/src/referral/utils/generate-referral-code.util.ts
+++ b/src/referral/utils/generate-referral-code.util.ts
@@ -1,4 +1,4 @@
-import { randomInt } from 'crypto';
+import { randomInt } from 'node:crypto';
 
 const CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 const CODE_LENGTH = 8;

--- a/src/referral/utils/generate-referral-code.util.ts
+++ b/src/referral/utils/generate-referral-code.util.ts
@@ -1,3 +1,5 @@
+import { randomInt } from 'crypto';
+
 const CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 const CODE_LENGTH = 8;
 const MAX_ATTEMPTS = 50;
@@ -14,7 +16,7 @@ export async function generateUniqueReferralCode(
     }
     code = '';
     for (let i = 0; i < CODE_LENGTH; i++) {
-      code += CHARS.charAt(Math.floor(Math.random() * CHARS.length));
+      code += CHARS.charAt(randomInt(CHARS.length));
     }
     attempts++;
   } while (await exists(code));


### PR DESCRIPTION
Closes #78 

---

## What & Why

Replace `Math.random()` with `crypto.randomInt()` for 2FA backup codes, referral code generation, and the close-roast script style picker. Addresses weak-PRNG security findings (Sonar) and improves unpredictability where it matters.

## Changes Summary

- `src/auth/services/two-factor.service.ts` — backup codes use `randomInt` from `crypto`.
- `src/referral/utils/generate-referral-code.util.ts` — referral characters use `randomInt`.
- `scripts/generate-close-roast.js` — roast style selection uses `randomInt`.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Maintenance, config, tooling

## Definition of Done

See [DEFINITION_OF_DONE.md](../../DEFINITION_OF_DONE.md).

- [x] **PR title** follows Conventional Commits (max 72 chars)
- [x] **Link issue:** `Closes #N` in body
- [ ] Code passes `yarn quality` (build, lint, test, format:check)
- [ ] No `any` in production code; explicit return types on service methods where applicable
- [ ] Unit tests for changed logic (or confirm existing specs cover behavior)
- [ ] Swagger docs updated for API changes — N/A
- [ ] No unresolved TODO comments
- [x] **ADR** — Not required for this change

## Architectural Decision

- [x] No architectural decision in this PR

## AI Assistance Disclosure

- [ ] No AI assistance used
- [x] AI assistance used — reviewed and understood

## Breaking Changes

None.

## Testing Instructions for Reviewer

1. `yarn build`
2. `yarn test` (or targeted: `two-factor.service.spec.ts`, `generate-referral-code.util.spec.ts` if run in isolation)
3. Optional: verify 2FA backup codes and referral flow in dev; formats unchanged.
